### PR TITLE
README link, `baseURL` with trailing slash

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -64,7 +64,7 @@ jobs:
           mkdir -p themes/hugo-geekdoc/
           curl -L https://github.com/thegeeklab/hugo-geekdoc/releases/download/v${GEEKDOC_VERSION}/hugo-geekdoc.tar.gz | \
             tar -xz -C themes/hugo-geekdoc/ --strip-components=1
-          hugo --baseURL "${{ steps.pages.outputs.base_url }}/"
+          hugo --baseURL "${{ steps.pages.outputs.base_url }}"
         # yamllint enable rule:line-length
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # pycon-redux
 
-Redux of learnings and talks from PyCon 2022 and onward.
+Redux of learnings and talks from PyCon 2022 and onward:
+https://jamesbraza.github.io/pycon-redux/
 
 ## Website
 
-This website was made with the static site generator [Hugo](https://gohugo.io/),
+The website is hosted via [GitHub Pages](https://pages.github.com/).
+It was made with the static site generator [Hugo](https://gohugo.io/),
 and the theme is [Geekdoc](https://themes.gohugo.io/themes/hugo-geekdoc/)
 ([GitHub repo](https://github.com/thegeeklab/hugo-geekdoc)).

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,4 +1,4 @@
-baseURL = "https://jamesbraza.github.io/pycon-redux"
+baseURL = "https://jamesbraza.github.io/pycon-redux/"
 theme = "hugo-geekdoc"
 title = "PyCon Redux"
 


### PR DESCRIPTION
- Added a link to the website in the `README`
- Added a trailing slash into the `baseURL` to match [the docs](https://geekdocs.de/usage/getting-started/#subdirectories)