### PR TITLE
PyCon 2022 day 3 content, beginnings of misc facts

### DIFF
--- a/content/en/2022/_index.md
+++ b/content/en/2022/_index.md
@@ -68,6 +68,14 @@ resources:
 
 {{< img name="pikachu-pants" size="tiny" >}}
 
+### [Building a Python Code Completer - Meredydd Luff]({{< ref "code-completer.md" >}})
+
+{{< include file="/2022/code-completer.md.part" >}}
+
+## Miscellaneous Facts and Sayings
+
+{{< include file="/2022/miscellaneous-facts-sayings.md.part" >}}
+
 [1]: {{< ref "match-statement.md" >}}
 [2]: {{< ref "adding-pipe-operator.md" >}}
 [3]: {{< ref "bug-elsewhere.md" >}}

--- a/content/en/2022/_index.md
+++ b/content/en/2022/_index.md
@@ -42,8 +42,6 @@ resources:
 
 ## Day 2
 
-{{< img name="better-error-messages" size="small" >}}
-
 ### [Keynote (Day 2) - Peter Wang]({{< ref "keynote-day2.md" >}})
 
 {{< include file="/2022/keynote-day2.md.part" >}}

--- a/content/en/2022/code-completer.md
+++ b/content/en/2022/code-completer.md
@@ -1,0 +1,11 @@
+---
+title: Code Completer
+draft: false
+weight: 210
+---
+
+{{< include file="/2022/code-completer.md.part" >}}
+
+<p></p>
+
+{{< youtube aRO7DkJrA_c >}}

--- a/content/en/2022/code-completer.md.part
+++ b/content/en/2022/code-completer.md.part
@@ -1,0 +1,3 @@
+A thought-provoking systems talk given by
+[Anvil](https://anvil.works/) founder Meredydd Luff,
+giving insight into a code completer's implementation.

--- a/content/en/2022/miscellaneous-facts-sayings.md.part
+++ b/content/en/2022/miscellaneous-facts-sayings.md.part
@@ -1,0 +1,7 @@
+- Typed your code?
+  Compile your code to C extensions with
+  [`mypyc`](https://github.com/mypyc/mypyc) for 10X speed boost
+- Instagram is fully Python, both frontend and backend,
+  and wrote a performance-oriented CPython 3.8-based runtime [`Cinder`][1]
+
+[1]: https://github.com/facebookincubator/cinder


### PR DESCRIPTION
- Adds first pass of day 3 content
- Adds first pass of miscellaneous facts/sayings (wip)
- Removes an broken `img` shortcode from `/2022/_index.md` I should have removed in https://github.com/jamesbraza/pycon-redux/pull/9