### PR TITLE
Table of contents in 2022

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -34,9 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GEEKDOC_VERSION: 0.39.4
-      # Match Hugo version used in Geekdocs CI
-      # SEE: https://github.com/thegeeklab/hugo-geekdoc/blob/main/.drone.yml#L29
-      HUGO_VERSION: 0.105.0
+      # NOTE: keep Hugo version >= 0.111.0, for table of contents improvements
+      HUGO_VERSION: 0.114.0
     steps:
       - name: Install Hugo CLI
         # yamllint disable rule:line-length

--- a/content/en/2022/_index.md
+++ b/content/en/2022/_index.md
@@ -18,6 +18,8 @@ resources:
 
 {{< img name="pycon-opener" size="small" >}}
 
+{{< toc >}}
+
 ## Day 1
 
 ### [Keynote (Day 1) - Łukasz Langa]({{< ref "keynote-day1.md" >}})

--- a/content/en/2022/performance-antipatterns.md.part
+++ b/content/en/2022/performance-antipatterns.md.part
@@ -1,6 +1,6 @@
 Microsoft has a team working on making Python faster (over 25% for Python 3.11),
 called the "Faster CPython" team.
-Brandt Bucher (gave the [`match` statement talk][1])
+Brandt Bucher (gave the `match` statement talk)
 and Anthony Shaw (gave this talk) are both team members.
 
 A savvy point made is to only optimize
@@ -13,13 +13,11 @@ It also suggests multiple tools:
 - The memory profiler [`Scalene`](https://github.com/plasma-umass/scalene)
 - For immediate huge performance gains,
   just switch Python interpreter: [`Pyston`][3]
-  (maintainer Kevin Modzelewski gave a [talk on performant code][6]),
+  (maintainer Kevin Modzelewski gave a talk on performant code),
   [`Cython`][4] (called "cythonizing"),
   or [`PyPy`][5] (JIT)
 
-[1]: {{< ref "match-statement.md" >}}
 [2]: https://docs.python.org/3/reference/datamodel.html#object.__slots__
 [3]: https://github.com/pyston/pyston
 [4]: https://github.com/cython/cython
 [5]: https://www.pypy.org/
-[6]: {{< ref "performant-code.md" >}}

--- a/content/en/2022/performance-antipatterns.md.part
+++ b/content/en/2022/performance-antipatterns.md.part
@@ -1,6 +1,6 @@
 Microsoft has a team working on making Python faster (over 25% for Python 3.11),
 called the "Faster CPython" team.
-Brandt Bucher (gave the `match` statement talk)
+Brandt Bucher (gave the [`match` statement talk][1])
 and Anthony Shaw (gave this talk) are both team members.
 
 A savvy point made is to only optimize
@@ -13,11 +13,13 @@ It also suggests multiple tools:
 - The memory profiler [`Scalene`](https://github.com/plasma-umass/scalene)
 - For immediate huge performance gains,
   just switch Python interpreter: [`Pyston`][3]
-  (maintainer Kevin Modzelewski gave a talk on performant code),
+  (maintainer Kevin Modzelewski gave the [performant code talk][6]),
   [`Cython`][4] (called "cythonizing"),
   or [`PyPy`][5] (JIT)
 
+[1]: {{< ref "match-statement.md" >}}
 [2]: https://docs.python.org/3/reference/datamodel.html#object.__slots__
 [3]: https://github.com/pyston/pyston
 [4]: https://github.com/cython/cython
 [5]: https://www.pypy.org/
+[6]: {{< ref "performant-code.md" >}}


### PR DESCRIPTION
- Adds an HTML table of contents to `2022`
    - Hugo version < 0.111.0 will hit a circular reference, so bumped version to current latest
- Tweaks wording in performance antipatterns page