### PR TITLE
PyCon 2023 day 2 and 3 content

### DIFF
--- a/content/en/2023/_index.md
+++ b/content/en/2023/_index.md
@@ -51,6 +51,16 @@ draft: false
 
 {{< include file="/2023/faster-cpython.md.part" >}}
 
+## Day 3
+
+### [Keynote (Day 1) - Guido van Rossum]({{< ref "keynote-day3.md" >}})
+
+{{< include file="/2023/keynote-day3.md.part" >}}
+
+## Miscellaneous Facts and Sayings
+
+{{< include file="/2023/miscellaneous-facts-sayings.md.part" >}}
+
 [1]: {{< ref "adaptive-interpreter.md" >}}
 [2]: {{< ref "timezones.md" >}}
 [3]: {{< ref "per-gil-interpreter.md" >}}

--- a/content/en/2023/_index.md
+++ b/content/en/2023/_index.md
@@ -21,7 +21,7 @@ draft: false
 
 {{< include file="/2023/adaptive-interpreter.md.part" >}}
 
-### [Working Around the GIL with asyncio]({{< ref "asyncio-and-gil.md" >}})
+### [Working Around the GIL with asyncio - Łukasz Langa]({{< ref "asyncio-and-gil.md" >}})
 
 {{< include file="/2023/asyncio-and-gil.md.part" >}}
 
@@ -37,7 +37,23 @@ draft: false
 
 {{< include file="/2023/nanoservices.md.part" >}}
 
+## Day 2
+
+### [Python's syntactic sugar - Brett Cannon]({{< ref "syntactic-sugar.md" >}})
+
+{{< include file="/2023/syntactic-sugar.md.part" >}}
+
+### [How memory profilers work - Pablo Galindo Salgado][5]
+
+{{< include file="/2023/memory-profilers.md.part" >}}
+
+### [How we are making CPython faster. Past, present and future. - Mark Shannon][6]
+
+{{< include file="/2023/faster-cpython.md.part" >}}
+
 [1]: {{< ref "adaptive-interpreter.md" >}}
 [2]: {{< ref "timezones.md" >}}
 [3]: {{< ref "per-gil-interpreter.md" >}}
 [4]: {{< ref "nanoservices.md" >}}
+[5]: {{< ref "memory-profilers.md" >}}
+[6]: {{< ref "faster-cpython.md" >}}

--- a/content/en/2023/adaptive-interpreter.md.part
+++ b/content/en/2023/adaptive-interpreter.md.part
@@ -9,7 +9,5 @@ please see [PEP 659][2] for more information on this.
 Brandt also made a tool [`specialist`][1] to visualize
 where the interpreter's optimization is succeeding or failing.
 
-Mark Shannon's talk on (related to XYZ)
-
 [1]: https://github.com/brandtbucher/specialist
 [2]: https://peps.python.org/pep-0659/

--- a/content/en/2023/faster-cpython.md
+++ b/content/en/2023/faster-cpython.md
@@ -1,0 +1,9 @@
+---
+title: Faster CPython
+draft: false
+weight: 120
+---
+
+{{< include file="/2023/faster-cpython.md.part" >}}
+
+{{< youtube wyty6sFMWI0 >}}

--- a/content/en/2023/faster-cpython.md.part
+++ b/content/en/2023/faster-cpython.md.part
@@ -1,0 +1,20 @@
+Mark Shannon [initially proposed how to speed CPython ~5X][1],
+now being enacted by the Faster CPython team (he's on it).
+
+This talk primarily talked about the optimizations on the
+memory overhead required for Python classes.
+To name a few of the iterations:
+Python 3.2 used 352 bytes/class,
+Python 3.6 used 192 bytes/class,
+and Python 3.12 used 96 bytes/class.
+Future optimization can bring this below 80 bytes/class.
+Mark also went over how specialization works
+(also see [Brandt Bucher's adaptive interpreter talk][2])
+and a few other Faster Cpython team efforts.
+
+A notable saying from the talk:
+
+- Nothing is faster than nothing
+
+[1]: https://github.com/markshannon/faster-cpython/blob/master/plan.md
+[2]: {{< ref "adaptive-interpreter.md" >}}

--- a/content/en/2023/keynote-day3.md
+++ b/content/en/2023/keynote-day3.md
@@ -1,0 +1,9 @@
+---
+title: Keynote (Day 3)
+draft: false
+weight: 210
+---
+
+{{< include file="/2023/keynote-day3.md.part" >}}
+
+{{< youtube yp6WuHFhYCo >}}

--- a/content/en/2023/keynote-day3.md.part
+++ b/content/en/2023/keynote-day3.md.part
@@ -1,0 +1,13 @@
+Guido van Rossum, the creator of Python,
+came to PyCon USA 2023 and gave a talk on the history
+of the many Python organization(s).
+He shared many success and failure stories of conference evolution,
+the ancestors of the [Python Software Foundation][1] (PSF),
+and the history of PyCon itself.
+
+A notable saying from the talk:
+
+- Programming languages are a way to communicate ideas to other people,
+  not just computers
+
+[1]: https://www.python.org/psf-landing/

--- a/content/en/2023/memory-profilers.md
+++ b/content/en/2023/memory-profilers.md
@@ -1,0 +1,11 @@
+---
+title: Memory Profilers
+draft: false
+weight: 115
+---
+
+{{< include file="/2023/memory-profilers.md.part" >}}
+
+<p></p>
+
+{{< youtube mqu66lg79X8 >}}

--- a/content/en/2023/memory-profilers.md.part
+++ b/content/en/2023/memory-profilers.md.part
@@ -1,0 +1,8 @@
+Bloomberg has open sourced a memory profiling tool [`memray`][1],
+of which Pablo is a main contributor.
+This visually appealing talk walks through the interaction
+between Python and the host OS,
+how a memory profiler can be inserted between them,
+and ways a memory profiler could function.
+
+[1]: https://github.com/bloomberg/memray

--- a/content/en/2023/miscellaneous-facts-sayings.md.part
+++ b/content/en/2023/miscellaneous-facts-sayings.md.part
@@ -1,0 +1,36 @@
+Memorable quotes or ideas:
+
+- "ChatGPT is a stochastic parrot"
+- Dogfooding: being a user of one's own products
+
+Python language learnings:
+
+- [PEP 701][4] in Python 3.12 allows for arbitrary code in f-strings.
+  No more alternation of `""` with `''`
+- Confusion of `str.lstrip` vs `str.removeprefix`
+  and `str.rstrip` vs `str.removesuffix` is a huge source of bugs
+- There's active development on direct integration of Python with
+  web apps and mobile apps
+
+Miscellaneous tooling findings:
+
+- `ARCHITECTURE.md` is a standard filename for documenting architecture,
+  especially architecture invariants and design boundaries
+- [Structured concurrency][2] can be accomplished using [`asyncio.TaskGroup`][1]
+- PyCharm's inspection tool is available independently from PyCharm
+  as the tool [Qodana][3]
+- PyPI is adding support for [organization accounts][5]
+- [`etckeeper`][6] enables version controls for `/etc`,
+  such that `apt install` or `apt upgrade` make an easily revert-able VCS commit
+- The Python Packaging Authority has a tool [`cibuildwheel`][7]
+  to build and test wheels for multiple platforms
+- Rust's unofficial mascot Ferris the crab is cute: [Rustacean.net][8]
+
+[1]: https://docs.python.org/3/library/asyncio-task.html#task-groups
+[2]: https://en.wikipedia.org/wiki/Structured_concurrency
+[3]: https://www.jetbrains.com/qodana/
+[4]: https://peps.python.org/pep-0701/
+[5]: https://docs.pypi.org/organization-accounts/
+[6]: https://ubuntu.com/server/docs/tools-etckeeper
+[7]: https://github.com/pypa/cibuildwheel
+[8]: https://rustacean.net/

--- a/content/en/2023/syntactic-sugar.md
+++ b/content/en/2023/syntactic-sugar.md
@@ -1,0 +1,9 @@
+---
+title: Syntactic Sugar
+draft: false
+weight: 110
+---
+
+{{< include file="/2023/syntactic-sugar.md.part" >}}
+
+{{< youtube 6gjvjkSs570 >}}

--- a/content/en/2023/syntactic-sugar.md.part
+++ b/content/en/2023/syntactic-sugar.md.part
@@ -1,0 +1,12 @@
+Brett Cannon is a core developer of Python,
+with over 1000 commits to CPython as of June 2023.
+
+His talk was a thought experiment:
+which parts of Python 3.8 syntax are mandatory,
+and which can be considered syntactic sugar?
+He found 10 pieces of syntax were mandatory
+(to name a few: integers, function calls + `def`, `while`, `raise`),
+and [here's the full analysis][1].
+The talk also reviews the Python data model in depth.
+
+[1]: https://snarky.ca/mvpy-minimum-viable-python/


### PR DESCRIPTION
- Adds day 2 and 3 talks, and memorable facts/sayings
- Adds forgotten author to GIL + `asyncio` talk
- Removes TODO for adaptive interpreter talk