### PR TITLE
Updating Geekdocs for page edit fix

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -33,9 +33,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GEEKDOC_VERSION: 0.39.5
+      GEEKDOC_VERSION: 0.40.1
       # NOTE: keep Hugo version >= 0.111.0, for table of contents improvements
-      HUGO_VERSION: 0.114.1
+      HUGO_VERSION: 0.115.4
     steps:
       - name: Install Hugo CLI
         # yamllint disable rule:line-length

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -7,8 +7,8 @@ geekdocNav: false
 
 <span class="badge-placeholder">[![Lint and Test](https://github.com/jamesbraza/pycon-redux/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/jamesbraza/pycon-redux/actions/workflows/lint-test.yaml)</span>
 <span class="badge-placeholder">[![Hugo Deploy](https://github.com/jamesbraza/pycon-redux/actions/workflows/hugo.yaml/badge.svg)](https://github.com/jamesbraza/pycon-redux/actions/workflows/hugo.yaml)</span>
-<span class="badge-placeholder">[![Hugo Version](https://img.shields.io/badge/Hugo-0.114.1-blue.svg)](https://gohugo.io)</span>
-<span class="badge-placeholder">[![Geekdocs Version](https://img.shields.io/badge/Geekdocs-0.39.5-blue.svg)](https://geekdocs.de/)</span>
+<span class="badge-placeholder">[![Hugo Version](https://img.shields.io/badge/Hugo-0.115.4-blue.svg)](https://gohugo.io)</span>
+<span class="badge-placeholder">[![Geekdocs Version](https://img.shields.io/badge/Geekdocs-0.40.1-blue.svg)](https://geekdocs.de/)</span>
 <span class="badge-placeholder">[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/jamesbraza/pycon-redux/blob/main/LICENSE)</span>
 
 The Python Conference (PyCon) is an amazing experience,


### PR DESCRIPTION
Updating Geekdocs for fix of edit page links ([released here](https://github.com/thegeeklab/hugo-geekdoc/releases/tag/v0.40.0))