### PR TITLE
Updating `baseURL` and fixed edit base path

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
         additional_dependencies:
           - sphinx
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: v3.0.0
     hooks:
       - id: prettier
   - repo: https://github.com/codespell-project/codespell
@@ -42,7 +42,7 @@ repos:
           - --check-hidden
           - --ignore-words-list=astroid,ned,ser
   - repo: https://github.com/myint/docformatter
-    rev: v1.7.0
+    rev: v1.7.5
     hooks:
       - id: docformatter
         args:
@@ -50,16 +50,16 @@ repos:
           - --pre-summary-newline
           - --black
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.274
+    rev: v0.0.280
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.0
+    rev: v1.4.1
     hooks:
       - id: mypy
   - repo: local

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://jamesbraza.github.io/pycon-redux/"
+baseURL = "https://pycon-redux.com"
 theme = "hugo-geekdoc"
 title = "PyCon Redux"
 

--- a/config.toml
+++ b/config.toml
@@ -27,7 +27,7 @@ languageName = "English"
 [params]
   # Enable 'Edit page' links. Requires 'geekdocRepo' param and the path must point to
   # the parent directory of the 'content' folder.
-  geekdocEditPath = "edit/main/pycon-redux"
+  geekdocEditPath = "edit/main"
 
   # (Optional, default static/brand.svg) Set the path to a logo for the Geekdoc
   # relative to your 'static/' folder.


### PR DESCRIPTION
- Moving to non-GitHub pages URL
- Fixed `geekdocEditPath` field (turns out https://github.com/jamesbraza/pycon-redux/pull/18 didn't quite do the trick)
- Also ran `pre-commit autoupdate`