### PR TITLE
Removed deploy badge from home

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -1,6 +1,6 @@
 ---
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
-name: Deploy Hugo Site
+name: Deploy Site
 
 on: # yamllint disable-line rule:truthy
   # Runs on pushes targeting the default branch

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pycon-redux.com
 
+![Lint and Test](https://github.com/jamesbraza/pycon-redux/actions/workflows/lint-test.yaml/badge.svg)
+![Deploy Site](https://github.com/jamesbraza/pycon-redux/actions/workflows/hugo.yaml/badge.svg)
+
 Redux of learnings and talks from PyCon 2022 and onward:
 https://pycon-redux.com/
 

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -6,7 +6,6 @@ geekdocNav: false
 ---
 
 <span class="badge-placeholder">[![Lint and Test](https://github.com/jamesbraza/pycon-redux/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/jamesbraza/pycon-redux/actions/workflows/lint-test.yaml)</span>
-<span class="badge-placeholder">[![Hugo Deploy](https://github.com/jamesbraza/pycon-redux/actions/workflows/hugo.yaml/badge.svg)](https://github.com/jamesbraza/pycon-redux/actions/workflows/hugo.yaml)</span>
 <span class="badge-placeholder">[![Hugo Version](https://img.shields.io/badge/Hugo-0.115.4-blue.svg)](https://gohugo.io)</span>
 <span class="badge-placeholder">[![Geekdocs Version](https://img.shields.io/badge/Geekdocs-0.40.1-blue.svg)](https://geekdocs.de/)</span>
 <span class="badge-placeholder">[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://github.com/jamesbraza/pycon-redux/blob/main/LICENSE)</span>


### PR DESCRIPTION
I chose to remove the deploy's badge from the homepage (if the site is live, the deploy is succeeding).  For convenience, I placed the badges in the README.